### PR TITLE
fix: package.json types field conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     }
   },
   "files": [


### PR DESCRIPTION
Fixes #180

Fix the order of conditions in `package.json` to ensure the 'types' condition is used correctly.

* Move the 'types' condition to line 24.
* Move the 'import' condition to line 25.
* Move the 'require' condition to line 26.

