### PR TITLE
fix(srpc): name the close that arrives without a completion

### DIFF
--- a/srpc/common-rpc.go
+++ b/srpc/common-rpc.go
@@ -307,9 +307,22 @@ func (c *commonRPC) handleStreamCloseLocked(
 	if c.dataClosed && c.writerClosed {
 		return nil
 	}
+	// A peer that closes its side reports the end of the stream. Transports
+	// disagree on whether they surface that as io.EOF or as no error at all,
+	// and it means the same thing either way, so settle it here rather than in
+	// each transport. It says nothing about whether a completion preceded it.
+	if errors.Is(closeErr, io.EOF) {
+		closeErr = nil
+	}
 	normalRemoteCloseAfterLocalComplete := closeErr == nil && (c.localCompleting || c.localDone)
 	if closeErr != nil && c.remoteErr == nil {
 		c.remoteErr = closeErr
+	}
+	// A clean close that arrives with no completion behind it leaves the call
+	// without a verdict. Reading io.EOF there says the stream ended in good
+	// order, which is the one thing we do not know.
+	if closeErr == nil && !normalRemoteCloseAfterLocalComplete && !c.remoteCompleted && c.remoteErr == nil {
+		c.remoteErr = ErrClosedBeforeCompletion
 	}
 	if !normalRemoteCloseAfterLocalComplete && !c.remoteTerminalSet {
 		terminal := TerminalKind_TERMINAL_KIND_CLOSED

--- a/srpc/common-rpc_test.go
+++ b/srpc/common-rpc_test.go
@@ -3,6 +3,7 @@ package srpc
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"sync"
 	"sync/atomic"
@@ -421,5 +422,88 @@ func TestCommonRPCReadOneQueuedDoesNotAllocate(t *testing.T) {
 
 	if allocs != 0 {
 		t.Fatalf("expected queued ReadOne to avoid allocations, got %f", allocs)
+	}
+}
+
+func TestRemoteCloseWithoutCompletionNamesTheMissingCompletion(t *testing.T) {
+	writer := &closeCountingPacketWriter{}
+	rpc := NewClientRPC(context.Background(), "service", "method")
+	if err := rpc.Start(writer, false, nil); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	// the transport ends the stream in good order with nothing behind it,
+	// which is what a dropped completion packet looks like from here.
+	rpc.HandleStreamClose(nil)
+
+	_, err := rpc.ReadOne()
+	if !errors.Is(err, ErrClosedBeforeCompletion) {
+		t.Fatalf("read after a truncated stream reported %v, want the missing completion", err)
+	}
+	if errors.Is(err, io.EOF) {
+		t.Fatalf("read after a truncated stream claims the call ended in good order: %v", err)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("read after a truncated stream stopped satisfying a cancellation check: %v", err)
+	}
+	if got := err.Error(); got == context.Canceled.Error() {
+		t.Fatalf("read after a truncated stream still claims a cancellation happened: %q", got)
+	}
+	if err := rpc.Wait(context.Background()); !errors.Is(err, ErrClosedBeforeCompletion) {
+		t.Fatalf("wait after a truncated stream reported %v, want the missing completion", err)
+	}
+}
+
+func TestRemoteCloseReportingEOFNamesTheMissingCompletion(t *testing.T) {
+	writer := &closeCountingPacketWriter{}
+	rpc := NewClientRPC(context.Background(), "service", "method")
+	if err := rpc.Start(writer, false, nil); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	// rpcstream surfaces the peer's close as io.EOF rather than as no error.
+	rpc.HandleStreamClose(io.EOF)
+
+	_, err := rpc.ReadOne()
+	if !errors.Is(err, ErrClosedBeforeCompletion) {
+		t.Fatalf("read after an EOF close reported %v, want the missing completion", err)
+	}
+	if terminal, ok := rpc.receiptTerminalKind(); !ok || terminal != TerminalKind_TERMINAL_KIND_CLOSED {
+		t.Fatalf("an EOF close recorded terminal %v, want a clean close", terminal)
+	}
+}
+
+func TestRemoteCloseAfterCompletionStillEndsTheStream(t *testing.T) {
+	writer := &closeCountingPacketWriter{}
+	rpc := NewClientRPC(context.Background(), "service", "method")
+	if err := rpc.Start(writer, false, nil); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	if err := rpc.HandleCallData(&CallData{Complete: true}); err != nil {
+		t.Fatalf("handle completion: %v", err)
+	}
+	rpc.HandleStreamClose(nil)
+
+	if _, err := rpc.ReadOne(); !errors.Is(err, io.EOF) {
+		t.Fatalf("read after a completed call reported %v, want the end of the stream", err)
+	}
+}
+
+func TestClientRPCCloseReportsALocalCancellation(t *testing.T) {
+	writer := &closeCountingPacketWriter{}
+	rpc := NewClientRPC(context.Background(), "service", "method")
+	if err := rpc.Start(writer, false, nil); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	rpc.Close()
+
+	_, err := rpc.ReadOne()
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("read after a local close reported %v, want a cancellation", err)
+	}
+	if errors.Is(err, ErrClosedBeforeCompletion) {
+		t.Fatalf("a close this side performed was blamed on the remote: %v", err)
 	}
 }

--- a/srpc/errors.go
+++ b/srpc/errors.go
@@ -1,6 +1,9 @@
 package srpc
 
-import "errors"
+import (
+	"context"
+	"errors"
+)
 
 var (
 	// ErrReset is returned when a stream is reset.
@@ -24,3 +27,25 @@ var (
 	// ErrNilWriter is returned if the rpc writer is nil.
 	ErrNilWriter = errors.New("writer cannot be nil")
 )
+
+// ErrClosedBeforeCompletion is the error a call reports when its stream closed
+// without the remote sending a completion or an error. The call has no verdict:
+// the handler may have finished with its answer lost in the transport, or it may
+// never have run. Anything read from the call after that point fails with this.
+//
+// It unwraps to context.Canceled, which is what this case reported before the
+// distinction existed, so a caller that tests for cancellation keeps working.
+var ErrClosedBeforeCompletion error = closedBeforeCompletion{}
+
+// closedBeforeCompletion carries ErrClosedBeforeCompletion.
+type closedBeforeCompletion struct{}
+
+// Error returns the error message.
+func (closedBeforeCompletion) Error() string {
+	return "stream closed before the remote reported completion"
+}
+
+// Unwrap returns the cancellation this case reported historically.
+func (closedBeforeCompletion) Unwrap() error {
+	return context.Canceled
+}


### PR DESCRIPTION
A call whose stream closes before the remote sends a completion or an error had no error of its own, so closeLocked substituted context.Canceled. Every read and every Wait on that call then reported a cancellation that nobody performed. The two cases are not the same and they need different responses: a cancellation says the work was stopped on purpose, while a stream that closed early says the call has no verdict at all, because the handler may have finished with its answer lost in the transport or may never have run.

Reporting the second as the first is expensive to debug. The message names a cause that is false, so the search starts at whoever might have canceled, and there is nobody there.

This introduces ErrClosedBeforeCompletion and reports it in place of the substituted cancellation. It unwraps to context.Canceled so that a caller written against the previous behavior still matches it.

The TypeScript implementation already draws this distinction. Its close path sets a remote error only when one is given, and it carries ERR_RPC_ABORT as a name of its own rather than borrowing a cancellation. Go was the odd one out.