### PR TITLE
feat(srpc): pass explicit server contexts

### DIFF
--- a/cmd/protoc-gen-es-starpc/typescript.ts
+++ b/cmd/protoc-gen-es-starpc/typescript.ts
@@ -26,6 +26,7 @@ import {
 } from '@aptre/protobuf-es-lite/protoplugin/ecmascript'
 
 const MessageStream = createImportSymbol('MessageStream', 'starpc')
+const ServerContext = createImportSymbol('ServerContext', 'starpc')
 const RuntimeMethodKind = createImportSymbol(
   'MethodKind',
   '@aptre/protobuf-es-lite',
@@ -124,6 +125,42 @@ function generateService(
     if (i < service.methods.length - 1) {
       f.print();
     }
+  }
+  f.print("}");
+  f.print();
+
+  // Generate the server implementation interface.
+  f.print(f.jsDoc(service));
+  f.print("export interface ", localName(service), "Handler {");
+  for (let i = 0; i < service.methods.length; i++) {
+    const method = service.methods[i];
+    f.print(f.jsDoc(method, "  "));
+    if (method.methodKind === MethodKind.Unary) {
+      f.print(
+        "  ", method.name,
+        "(request: ", method.input, ", abortSignal: AbortSignal, context: ", ServerContext, "): ",
+        "Promise<", method.output, ">;"
+      );
+    } else if (method.methodKind === MethodKind.ServerStreaming) {
+      f.print(
+        "  ", method.name,
+        "(request: ", method.input, ", abortSignal: AbortSignal, context: ", ServerContext, "): ",
+        MessageStream, "<", method.output, ">;"
+      );
+    } else if (method.methodKind === MethodKind.ClientStreaming) {
+      f.print(
+        "  ", method.name,
+        "(request: ", MessageStream, "<", method.input, ">, abortSignal: AbortSignal, context: ", ServerContext, "): ",
+        "Promise<", method.output, ">;"
+      );
+    } else if (method.methodKind === MethodKind.BiDiStreaming) {
+      f.print(
+        "  ", method.name,
+        "(request: ", MessageStream, "<", method.input, ">, abortSignal: AbortSignal, context: ", ServerContext, "): ",
+        MessageStream, "<", method.output, ">;"
+      );
+    }
+    if (i < service.methods.length - 1) f.print();
   }
   f.print("}");
   f.print();

--- a/echo/echo_srpc.pb.ts
+++ b/echo/echo_srpc.pb.ts
@@ -11,6 +11,7 @@ import {
   buildEncodeMessageTransform,
   MessageStream,
   ProtoRpc,
+  ServerContext,
 } from 'starpc'
 
 /**
@@ -149,6 +150,79 @@ export interface Echoer {
    * @generated from rpc echo.Echoer.DoNothing
    */
   DoNothing(request: Empty, abortSignal?: AbortSignal): Promise<Empty>
+}
+
+/**
+ * Echoer service returns the given message.
+ *
+ * @generated from service echo.Echoer
+ */
+export interface EchoerHandler {
+  /**
+   * Echo returns the given message.
+   *
+   * @generated from rpc echo.Echoer.Echo
+   */
+  Echo(
+    request: EchoMsg,
+    abortSignal: AbortSignal,
+    context: ServerContext,
+  ): Promise<EchoMsg>
+
+  /**
+   * EchoServerStream is an example of a server -> client one-way stream.
+   *
+   * @generated from rpc echo.Echoer.EchoServerStream
+   */
+  EchoServerStream(
+    request: EchoMsg,
+    abortSignal: AbortSignal,
+    context: ServerContext,
+  ): MessageStream<EchoMsg>
+
+  /**
+   * EchoClientStream is an example of client->server one-way stream.
+   *
+   * @generated from rpc echo.Echoer.EchoClientStream
+   */
+  EchoClientStream(
+    request: MessageStream<EchoMsg>,
+    abortSignal: AbortSignal,
+    context: ServerContext,
+  ): Promise<EchoMsg>
+
+  /**
+   * EchoBidiStream is an example of a two-way stream.
+   *
+   * @generated from rpc echo.Echoer.EchoBidiStream
+   */
+  EchoBidiStream(
+    request: MessageStream<EchoMsg>,
+    abortSignal: AbortSignal,
+    context: ServerContext,
+  ): MessageStream<EchoMsg>
+
+  /**
+   * RpcStream opens a nested rpc call stream.
+   *
+   * @generated from rpc echo.Echoer.RpcStream
+   */
+  RpcStream(
+    request: MessageStream<RpcStreamPacket>,
+    abortSignal: AbortSignal,
+    context: ServerContext,
+  ): MessageStream<RpcStreamPacket>
+
+  /**
+   * DoNothing does nothing.
+   *
+   * @generated from rpc echo.Echoer.DoNothing
+   */
+  DoNothing(
+    request: Empty,
+    abortSignal: AbortSignal,
+    context: ServerContext,
+  ): Promise<Empty>
 }
 
 export const EchoerServiceName = EchoerDefinition.typeName

--- a/echo/server.ts
+++ b/echo/server.ts
@@ -3,14 +3,15 @@ import { Message } from '@aptre/protobuf-es-lite'
 import { Empty } from '@aptre/protobuf-es-lite/google/protobuf/empty'
 import { EchoMsg } from './echo.pb.js'
 import { Server } from '../srpc/server.js'
+import type { ServerContext } from '../srpc/server-context.js'
 import { messagePushable, writeToPushable } from '../srpc/pushable.js'
 import { RpcStreamPacket } from '../rpcstream/rpcstream.pb.js'
 import { MessageStream } from '../srpc/message.js'
 import { handleRpcStream, RpcStreamHandler } from '../rpcstream/rpcstream.js'
-import { Echoer } from './echo_srpc.pb.js'
+import type { EchoerHandler } from './echo_srpc.pb.js'
 
 // EchoServer implements the Echoer server.
-export class EchoerServer implements Echoer {
+export class EchoerServer implements EchoerHandler {
   // proxyServer is the server used for RpcStream requests.
   private proxyServer?: Server
 
@@ -18,11 +19,19 @@ export class EchoerServer implements Echoer {
     this.proxyServer = proxyServer
   }
 
-  public async Echo(request: EchoMsg): Promise<Message<EchoMsg>> {
+  public async Echo(
+    request: EchoMsg,
+    _abortSignal: AbortSignal,
+    _context: ServerContext,
+  ): Promise<Message<EchoMsg>> {
     return request
   }
 
-  public async *EchoServerStream(request: EchoMsg): MessageStream<EchoMsg> {
+  public async *EchoServerStream(
+    request: EchoMsg,
+    _abortSignal: AbortSignal,
+    _context: ServerContext,
+  ): MessageStream<EchoMsg> {
     for (let i = 0; i < 5; i++) {
       yield request
       await new Promise((resolve) => setTimeout(resolve, 200))
@@ -31,6 +40,8 @@ export class EchoerServer implements Echoer {
 
   public async EchoClientStream(
     request: MessageStream<EchoMsg>,
+    _abortSignal: AbortSignal,
+    _context: ServerContext,
   ): Promise<Message<EchoMsg>> {
     // return the first message sent by the client.
     const message = await first(request)
@@ -42,6 +53,8 @@ export class EchoerServer implements Echoer {
 
   public EchoBidiStream(
     request: MessageStream<EchoMsg>,
+    _abortSignal: AbortSignal,
+    _context: ServerContext,
   ): MessageStream<EchoMsg> {
     // build result observable
     const result = messagePushable<EchoMsg>()
@@ -52,6 +65,8 @@ export class EchoerServer implements Echoer {
 
   public RpcStream(
     request: MessageStream<RpcStreamPacket>,
+    _abortSignal: AbortSignal,
+    _context: ServerContext,
   ): MessageStream<RpcStreamPacket> {
     return handleRpcStream(
       request[Symbol.asyncIterator](),
@@ -64,7 +79,11 @@ export class EchoerServer implements Echoer {
     )
   }
 
-  public async DoNothing(): Promise<Empty> {
+  public async DoNothing(
+    _request: Empty,
+    _abortSignal: AbortSignal,
+    _context: ServerContext,
+  ): Promise<Empty> {
     return {}
   }
 }

--- a/mock/mock_srpc.pb.ts
+++ b/mock/mock_srpc.pb.ts
@@ -4,7 +4,7 @@
 
 import { MockMsg } from './mock.pb.js'
 import { MethodKind } from '@aptre/protobuf-es-lite'
-import { ProtoRpc } from 'starpc'
+import { ProtoRpc, ServerContext } from 'starpc'
 
 /**
  * Mock service mocks some RPCs for the e2e tests.
@@ -40,6 +40,24 @@ export interface Mock {
    * @generated from rpc e2e.mock.Mock.MockRequest
    */
   MockRequest(request: MockMsg, abortSignal?: AbortSignal): Promise<MockMsg>
+}
+
+/**
+ * Mock service mocks some RPCs for the e2e tests.
+ *
+ * @generated from service e2e.mock.Mock
+ */
+export interface MockHandler {
+  /**
+   * MockRequest runs a mock unary request.
+   *
+   * @generated from rpc e2e.mock.Mock.MockRequest
+   */
+  MockRequest(
+    request: MockMsg,
+    abortSignal: AbortSignal,
+    context: ServerContext,
+  ): Promise<MockMsg>
 }
 
 export const MockServiceName = MockDefinition.typeName

--- a/srpc/channel.test.ts
+++ b/srpc/channel.test.ts
@@ -1,9 +1,29 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { pushable } from 'it-pushable'
 
 import { ChannelStream } from './channel.js'
 
 describe('ChannelStream', () => {
+  it('recognizes MessagePort implementations from another realm', () => {
+    const port = {
+      close: vi.fn(),
+      onmessage: null,
+      postMessage: vi.fn(),
+      start: vi.fn(),
+    } as unknown as MessagePort
+
+    const stream = new ChannelStream<Uint8Array>('client', port)
+    try {
+      expect(port.start).toHaveBeenCalledOnce()
+      expect(port.postMessage).toHaveBeenCalledWith({
+        ack: true,
+        from: 'client',
+      })
+    } finally {
+      stream.close()
+    }
+  })
+
   it('keeps MessagePort peer writes open after local source completes normally', async () => {
     const { port1, port2 } = new MessageChannel()
     const client = new ChannelStream<Uint8Array>('client', port1)

--- a/srpc/channel.ts
+++ b/srpc/channel.ts
@@ -26,6 +26,10 @@ export type ChannelPort =
   | MessagePort
   | { tx: BroadcastChannel; rx: BroadcastChannel }
 
+function isMessagePort(channel: ChannelPort): channel is MessagePort {
+  return 'postMessage' in channel && 'start' in channel
+}
+
 // ChannelStreamOpts are options for ChannelStream.
 export interface ChannelStreamOpts {
   // remoteOpen indicates that the remote already knows the channel is open.
@@ -149,7 +153,7 @@ export class ChannelStream<T = Uint8Array> implements Duplex<
 
     // wire up the message handlers
     const onMessage = this.onMessage.bind(this)
-    if (channel instanceof MessagePort) {
+    if (isMessagePort(channel)) {
       // MessagePort
       channel.onmessage = onMessage
       channel.start()
@@ -180,7 +184,7 @@ export class ChannelStream<T = Uint8Array> implements Duplex<
       return
     }
     msg.from = this.localId
-    if (this.channel instanceof MessagePort) {
+    if (isMessagePort(this.channel)) {
       this.channel.postMessage(msg)
     } else {
       this.channel.tx.postMessage(msg)
@@ -222,7 +226,7 @@ export class ChannelStream<T = Uint8Array> implements Duplex<
     this.localWriteClosed = true
     this.remoteWriteClosed = true
     // close channels
-    if (this.channel instanceof MessagePort) {
+    if (isMessagePort(this.channel)) {
       this.channel.onmessage = null
       this.channel.close()
     } else {

--- a/srpc/handler.ts
+++ b/srpc/handler.ts
@@ -1,12 +1,58 @@
 import type { Sink, Source } from 'it-stream-types'
-import { ServiceDefinition, ServiceMethodDefinitions } from './definition.js'
+import { MethodKind, type MessageType } from '@aptre/protobuf-es-lite'
+import type { MessageStream } from './message.js'
+import {
+  type MethodDefinition,
+  ServiceDefinition,
+  ServiceMethodDefinitions,
+} from './definition.js'
 import { createInvokeFn } from './invoker.js'
+import type { ServerContext } from './server-context.js'
+
+type MessageOf<T> = T extends MessageType<infer M> ? M : never
+
+type ServerMethod<T> =
+  T extends MethodDefinition<
+    infer Request,
+    infer Response,
+    infer Kind,
+    infer _Idempotency
+  >
+    ? Kind extends MethodKind.Unary
+      ? (
+          request: MessageOf<Request>,
+          abortSignal: AbortSignal,
+          context: ServerContext,
+        ) => Promise<MessageOf<Response>>
+      : Kind extends MethodKind.ServerStreaming
+        ? (
+            request: MessageOf<Request>,
+            abortSignal: AbortSignal,
+            context: ServerContext,
+          ) => MessageStream<MessageOf<Response>>
+        : Kind extends MethodKind.ClientStreaming
+          ? (
+              request: MessageStream<MessageOf<Request>>,
+              abortSignal: AbortSignal,
+              context: ServerContext,
+            ) => Promise<MessageOf<Response>>
+          : (
+              request: MessageStream<MessageOf<Request>>,
+              abortSignal: AbortSignal,
+              context: ServerContext,
+            ) => MessageStream<MessageOf<Response>>
+    : never
+
+export type HandlerImplementation<T extends ServiceMethodDefinitions> =
+  Partial<{
+    [Method in keyof T]: ServerMethod<T[Method]>
+  }>
 
 // InvokeFn describes an SRPC call method invoke function.
 export type InvokeFn = (
   dataSource: Source<Uint8Array>,
   dataSink: Sink<Source<Uint8Array>>,
-  invocation?: AbortSignal,
+  context: ServerContext,
 ) => Promise<void>
 
 // Handler describes a SRPC call handler implementation.
@@ -62,7 +108,11 @@ export class StaticHandler implements Handler {
 // if serviceID is not set, uses the fullName of the service as the identifier.
 export function createHandler<
   T extends ServiceMethodDefinitions = ServiceMethodDefinitions,
->(definition: ServiceDefinition<T>, impl: any, serviceID?: string): Handler {
+>(
+  definition: ServiceDefinition<T>,
+  impl: HandlerImplementation<T>,
+  serviceID?: string,
+): Handler {
   // serviceID defaults to the full name of the service from Protobuf.
   serviceID = serviceID || definition.typeName
 
@@ -70,7 +120,7 @@ export function createHandler<
   const methodMap: MethodMap = {}
   for (const methodInfo of Object.values(definition.methods)) {
     const methodName = methodInfo.name
-    let methodProto = impl[methodName]
+    let methodProto = impl[methodName as keyof T] as any
     if (!methodProto) {
       continue
     }

--- a/srpc/index.ts
+++ b/srpc/index.ts
@@ -83,3 +83,10 @@ export {
 } from './pushable.js'
 export { Watchdog } from './watchdog.js'
 export type { ProtoRpc } from './proto-rpc.js'
+
+export {
+  createContextKey,
+  serverContextValue,
+  withServerContextValue,
+} from './server-context.js'
+export type { ContextKey, ServerContext } from './server-context.js'

--- a/srpc/invoker.ts
+++ b/srpc/invoker.ts
@@ -2,6 +2,7 @@ import { Sink, Source } from 'it-stream-types'
 import { pushable } from 'it-pushable'
 import { pipe } from 'it-pipe'
 import type { MethodDefinition } from './definition.js'
+import type { ServerContext } from './server-context.js'
 import { InvokeFn } from './handler.js'
 import {
   buildDecodeMessageTransform,
@@ -13,10 +14,26 @@ import { MethodIdempotency, MethodKind } from '@aptre/protobuf-es-lite'
 
 // MethodProto is a function which matches one of the RPC signatures.
 export type MethodProto<R extends Message<R>, O extends Message<O>> =
-  | ((request: R, invocation?: AbortSignal) => Promise<O>)
-  | ((request: R, invocation?: AbortSignal) => AsyncIterable<O>)
-  | ((request: AsyncIterable<R>, invocation?: AbortSignal) => Promise<O>)
-  | ((request: AsyncIterable<R>, invocation?: AbortSignal) => AsyncIterable<O>)
+  | ((
+      request: R,
+      abortSignal: AbortSignal,
+      context: ServerContext,
+    ) => Promise<O>)
+  | ((
+      request: R,
+      abortSignal: AbortSignal,
+      context: ServerContext,
+    ) => AsyncIterable<O>)
+  | ((
+      request: AsyncIterable<R>,
+      abortSignal: AbortSignal,
+      context: ServerContext,
+    ) => Promise<O>)
+  | ((
+      request: AsyncIterable<R>,
+      abortSignal: AbortSignal,
+      context: ServerContext,
+    ) => AsyncIterable<O>)
 
 // createInvokeFn builds an InvokeFn from a method definition and a function prototype.
 export function createInvokeFn<R extends Message<R>, O extends Message<O>>(
@@ -32,7 +49,7 @@ export function createInvokeFn<R extends Message<R>, O extends Message<O>>(
   return async (
     dataSource: Source<Uint8Array>,
     dataSink: Sink<Source<Uint8Array>>,
-    invocation?: AbortSignal,
+    context: ServerContext,
   ) => {
     // responseSink is a Sink for response messages.
     const responseSink = pushable<O>({
@@ -67,7 +84,7 @@ export function createInvokeFn<R extends Message<R>, O extends Message<O>>(
 
     // Call the implementation.
     try {
-      const responseObj = methodProto(requestArg, invocation)
+      const responseObj = methodProto(requestArg, context.signal, context)
       if (!responseObj) {
         throw new Error('return value was undefined')
       }

--- a/srpc/server-context.ts
+++ b/srpc/server-context.ts
@@ -1,0 +1,55 @@
+declare const contextKeyValue: unique symbol
+const contextParent = Symbol('server context parent')
+const contextKey = Symbol('server context key')
+const contextStoredValue = Symbol('server context value')
+
+// ContextKey identifies one typed server-context value.
+export interface ContextKey<T> {
+  readonly [contextKeyValue]?: T
+}
+
+// ServerContext carries cancellation for one server invocation.
+export interface ServerContext {
+  readonly signal: AbortSignal
+}
+
+type StoredServerContext = ServerContext & {
+  readonly [contextParent]?: ServerContext
+  readonly [contextKey]?: ContextKey<unknown>
+  readonly [contextStoredValue]?: unknown
+}
+
+// createContextKey constructs an identity key for one server-context value.
+export function createContextKey<T>(): ContextKey<T> {
+  return {}
+}
+
+// withServerContextValue derives a context with one immutable typed value.
+export function withServerContextValue<T>(
+  context: ServerContext,
+  key: ContextKey<T>,
+  value: T,
+): ServerContext {
+  const derived: StoredServerContext = {
+    signal: context.signal,
+    [contextParent]: context,
+    [contextKey]: key as ContextKey<unknown>,
+    [contextStoredValue]: value,
+  }
+  return derived
+}
+
+// serverContextValue retrieves the nearest value for a typed identity key.
+export function serverContextValue<T>(
+  context: ServerContext,
+  key: ContextKey<T>,
+): T | undefined {
+  let current: StoredServerContext | undefined = context as StoredServerContext
+  while (current) {
+    if (current[contextKey] === key) {
+      return current[contextStoredValue] as T
+    }
+    current = current[contextParent] as StoredServerContext | undefined
+  }
+  return undefined
+}

--- a/srpc/server-rpc.ts
+++ b/srpc/server-rpc.ts
@@ -4,6 +4,7 @@ import type { CallData, CallStart } from './rpcproto.pb.js'
 import { CommonRPC } from './common-rpc.js'
 import { InvokeFn } from './handler.js'
 import { LookupMethod } from './mux.js'
+import type { ServerContext } from './server-context.js'
 
 // ServerRPC is an ongoing RPC from the server side.
 export class ServerRPC extends CommonRPC {
@@ -47,7 +48,9 @@ export class ServerRPC extends CommonRPC {
   private async invokeRPC(invokeFn: InvokeFn) {
     const dataSink = this._createDataSink()
     try {
-      await invokeFn(this.rpcDataSource, dataSink, this.invocationSignal)
+      await invokeFn(this.rpcDataSource, dataSink, {
+        signal: this.invocationSignal,
+      } satisfies ServerContext)
     } catch (err) {
       this.close(err as Error)
     }

--- a/srpc/server.test.ts
+++ b/srpc/server.test.ts
@@ -10,6 +10,10 @@ import {
   combineUint8ArrayListTransform,
   ChannelStreamOpts,
   Packet,
+  createContextKey,
+  serverContextValue,
+  withServerContextValue,
+  type ServerContext,
 } from '../srpc/index.js'
 import {
   EchoerDefinition,
@@ -78,12 +82,21 @@ describe('srpc server', () => {
   it('should pass rpc stream tests', async () => {
     await runRpcStreamTest(client)
   })
-  it('passes the exact invocation signal after async request decode', async () => {
+  it('passes the exact invocation context after async request decode', async () => {
     const controller = new AbortController()
-    let observedSignal: AbortSignal | undefined
+    const callerKey = createContextKey<string>()
+    let observedAbortSignal: AbortSignal | undefined
+    let observedContextSignal: AbortSignal | undefined
+    let observedCaller: string | undefined
     const handler = createHandler(EchoerDefinition, {
-      Echo: async (request: EchoMsgType, signal?: AbortSignal) => {
-        observedSignal = signal
+      Echo: async (
+        request: EchoMsgType,
+        abortSignal: AbortSignal,
+        context: ServerContext,
+      ) => {
+        observedAbortSignal = abortSignal
+        observedContextSignal = context.signal
+        observedCaller = serverContextValue(context, callerKey)
         return request
       },
     })
@@ -104,9 +117,41 @@ describe('srpc server', () => {
         }
         drained.resolve()
       },
-      controller.signal,
+      withServerContextValue(
+        { signal: controller.signal },
+        callerKey,
+        'caller-1',
+      ),
     )
     await drained.promise
+    expect(observedAbortSignal).toBe(controller.signal)
+    expect(observedContextSignal).toBe(controller.signal)
+    expect(observedCaller).toBe('caller-1')
+  })
+
+  it('keeps two-argument server handlers compatible', async () => {
+    const controller = new AbortController()
+    let observedSignal: AbortSignal | undefined
+    const handler = createHandler(EchoerDefinition, {
+      Echo: async (request: EchoMsgType, abortSignal?: AbortSignal) => {
+        observedSignal = abortSignal
+        return request
+      },
+    })
+    const invokeFn = await handler.lookupMethod(EchoerServiceName, 'Echo')
+    if (!invokeFn) throw new Error('Echo method was not found')
+    const request = EchoMsg.create({ body: 'legacy handler' })
+    await invokeFn(
+      (async function* () {
+        yield EchoMsg.toBinary(request)
+      })(),
+      async (source) => {
+        for await (const _data of source) {
+          // Drain the response.
+        }
+      },
+      { signal: controller.signal },
+    )
     expect(observedSignal).toBe(controller.signal)
   })
 

--- a/srpc/watchdog.test.ts
+++ b/srpc/watchdog.test.ts
@@ -7,6 +7,7 @@ describe('Watchdog', () => {
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     vi.restoreAllMocks()
   })
 


### PR DESCRIPTION
StarPC currently gives server handlers the client-facing AbortSignal argument, so higher-level protocols can only associate invocation capabilities through ambient state keyed by cancellation identity. Concurrent calls that reuse one signal can overwrite each other, and cancellation becomes an authority lookup mechanism.

Pass an immutable ServerContext to every server handler while preserving AbortSignal on context.signal. Add identity-based typed context keys, generate separate server Handler interfaces, and type createHandler implementations against their service definitions. Client interfaces remain unchanged.

Also recognize MessagePort implementations by their transport operations so ports from another JavaScript realm use the MessagePort path, and restore real timers after watchdog tests so concurrent server-streaming tests make progress.