### PR TITLE
feat(python): open independent Unix streams

### DIFF
--- a/python/tests/test_stream.py
+++ b/python/tests/test_stream.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Any
 
 from srpc import rpcproto_pb2
@@ -10,9 +12,11 @@ from starpc.codec import AsyncPacketWriter, PacketDecoder
 from starpc.stream import (
     ByteStream,
     StreamClosedError,
+    TCPByteStream,
     TCPStreamServer,
     memory_stream_pair,
     open_tcp_stream,
+    open_unix_stream,
 )
 
 
@@ -267,6 +271,72 @@ class StreamTest(unittest.IsolatedAsyncioTestCase):
             if client is not None:
                 await client.aclose()
             await server.aclose()
+
+
+class UnixStreamTest(unittest.IsolatedAsyncioTestCase):
+    async def assert_task_blocked(self, task: asyncio.Task[Any]) -> None:
+        with self.assertRaises(asyncio.TimeoutError):
+            await asyncio.wait_for(asyncio.shield(task), 0.01)
+
+    async def test_unix_connections_are_independent_and_half_close(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "starpc.sock"
+            accepted: asyncio.Queue[TCPByteStream] = asyncio.Queue()
+
+            def on_connection(
+                reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+            ) -> None:
+                accepted.put_nowait(TCPByteStream(reader, writer))
+
+            server = await asyncio.start_unix_server(on_connection, path)
+            try:
+                for value in (b"one", b"two"):
+                    client = await open_unix_stream(str(path))
+                    peer = await asyncio.wait_for(accepted.get(), 1)
+                    try:
+                        await client.write(value)
+                        await client.write_eof()
+                        self.assertEqual(await peer.read(100), value)
+                        self.assertEqual(await peer.read(1), b"")
+                        await peer.write(value.upper())
+                        await peer.write_eof()
+                        self.assertEqual(await client.read(100), value.upper())
+                        self.assertEqual(await client.read(1), b"")
+                    finally:
+                        await peer.aclose()
+                        await client.aclose()
+            finally:
+                server.close()
+                await server.wait_closed()
+
+    async def test_unix_close_wakes_read_and_missing_path_fails(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "starpc.sock"
+            accepted: asyncio.Queue[TCPByteStream] = asyncio.Queue()
+
+            def on_connection(
+                reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+            ) -> None:
+                accepted.put_nowait(TCPByteStream(reader, writer))
+
+            server = await asyncio.start_unix_server(on_connection, path)
+            client = await open_unix_stream(str(path))
+            peer = await asyncio.wait_for(accepted.get(), 1)
+            blocked_read = asyncio.create_task(client.read(1))
+            try:
+                await self.assert_task_blocked(blocked_read)
+                await client.aclose()
+                self.assertEqual(await asyncio.wait_for(blocked_read, 1), b"")
+            finally:
+                await cancel_task(blocked_read)
+                await peer.aclose()
+                await client.aclose()
+                server.close()
+                await server.wait_closed()
+
+            path.unlink()
+            with self.assertRaises(OSError):
+                await open_unix_stream(str(path))
 
 
 if __name__ == "__main__":

--- a/starpc/stream.py
+++ b/starpc/stream.py
@@ -141,7 +141,7 @@ def memory_stream_pair(
 
 
 class TCPByteStream:
-    """Adapt one asyncio TCP connection to the byte-stream contract."""
+    """Adapt one asyncio stream connection to the byte-stream contract."""
 
     def __init__(
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
@@ -189,6 +189,13 @@ async def open_tcp_stream(host: str, port: int) -> TCPByteStream:
     """Open one independent TCP byte stream."""
 
     reader, writer = await asyncio.open_connection(host, port)
+    return TCPByteStream(reader, writer)
+
+
+async def open_unix_stream(path: str) -> ByteStream:
+    """Open one independent Unix byte stream."""
+
+    reader, writer = await asyncio.open_unix_connection(path)
     return TCPByteStream(reader, writer)
 
 
@@ -298,4 +305,5 @@ __all__ = [
     "TCPStreamServer",
     "memory_stream_pair",
     "open_tcp_stream",
+    "open_unix_stream",
 ]


### PR DESCRIPTION
Python callers can open StarPC byte streams over memory and TCP, but a local Unix endpoint still requires each caller to reconstruct the asyncio adapter. That prevents local-process clients from using the supported `ByteStream` path.

This change adds `open_unix_stream` to adapt one asyncio Unix connection through the existing stream implementation. Each call opens an independent connection, preserves bidirectional half-close behavior, and leaves listener and socket-path custody with the endpoint process.

Focused tests exercise repeated calls, traffic in both directions after a half-close, forced local close, and a missing endpoint. The adapter adds no listener, process lifecycle, multiplexing, or transport registry.