### PR TITLE
test(srpc): bound packet vector frame size

### DIFF
--- a/srpc/packet-codec-vectors_test.go
+++ b/srpc/packet-codec-vectors_test.go
@@ -84,8 +84,12 @@ func decodeHex(t *testing.T, value string) []byte {
 
 func framePacket(t *testing.T, packet *Packet) []byte {
 	t.Helper()
-	frame := make([]byte, 4+packet.SizeVT())
-	binary.LittleEndian.PutUint32(frame, uint32(packet.SizeVT()))
+	packetSize := packet.SizeVT()
+	if packetSize > maxMessageSize {
+		t.Fatalf("packet size %d exceeds maximum %d", packetSize, maxMessageSize)
+	}
+	frame := make([]byte, 4+packetSize)
+	binary.LittleEndian.PutUint32(frame, uint32(packetSize)) //nolint:gosec // bounded by maxMessageSize
 	if _, err := packet.MarshalToSizedBufferVT(frame[4:]); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The golden-vector helper converts an arbitrary encoded packet size to a `uint32` without first establishing the protocol frame bound. Gosec now rejects that unchecked conversion and leaves the Go CI job red on `master`.

This change reuses the packet codec’s existing maximum message size before allocating and encoding the frame. The guarded conversion matches `WritePacket` and keeps the golden vectors on the same wire limit as production.