### PR TITLE
feat(rpcstream): add Python nested RPC streams

### DIFF
--- a/echo/client-test.ts
+++ b/echo/client-test.ts
@@ -2,7 +2,10 @@ import { Client, ERR_RPC_ABORT } from '../srpc/index.js'
 import { EchoMsg } from './echo.pb.js'
 import { EchoerClient } from './echo_srpc.pb.js'
 import { pushable } from 'it-pushable'
-import { buildRpcStreamOpenStream } from '../rpcstream/rpcstream.js'
+import {
+  buildRpcStreamOpenStream,
+  openRpcStream,
+} from '../rpcstream/rpcstream.js'
 import { Message } from '@aptre/protobuf-es-lite'
 
 export async function runClientTest(client: Client) {
@@ -89,8 +92,19 @@ export async function runAbortControllerTest(client: Client) {
   })
 }
 
+function requireError(
+  error: unknown,
+  label: string,
+  fragments: string[],
+): void {
+  const message = error instanceof Error ? error.message : String(error)
+  if (!fragments.some((fragment) => message.includes(fragment))) {
+    throw new Error(`${label} returned unexpected error: ${message}`)
+  }
+}
+
 // runRpcStreamTest tests a RPCStream.
-export async function runRpcStreamTest(client: Client) {
+export async function runRpcStreamTest(client: Client, release = false) {
   console.log('Calling RpcStream to open a RPC stream client...')
   const service = new EchoerClient(client)
   const openStreamFn = buildRpcStreamOpenStream(
@@ -106,4 +120,112 @@ export async function runRpcStreamTest(client: Client) {
 
   console.log('Running client test over RPC stream...')
   await runClientTest(proxiedClient)
+
+  if (release) {
+    let unknownRejected = false
+    try {
+      await openRpcStream('missing', service.RpcStream.bind(service), true)
+    } catch (error) {
+      unknownRejected = true
+      requireError(error, 'unknown component', ['unknown component: missing'])
+    }
+    if (!unknownRejected) {
+      throw new Error('unknown component unexpectedly succeeded')
+    }
+  }
+
+  let methodRejected = false
+  try {
+    await proxiedClient.request('missing.Service', 'Missing', new Uint8Array())
+  } catch (error) {
+    methodRejected = true
+    requireError(error, 'unknown nested method', [
+      'missing.Service',
+      'unimplemented',
+    ])
+  }
+  if (!methodRejected) {
+    throw new Error('unknown nested method unexpectedly succeeded')
+  }
+
+  if (release) {
+    const terminalService = new EchoerClient(proxiedClient)
+    let terminalFailed = false
+    try {
+      await terminalService.Echo({ body: '__nested_error__' })
+    } catch (error) {
+      terminalFailed = true
+      requireError(error, 'terminal nested error', ['nested terminal error'])
+    }
+    if (!terminalFailed) {
+      throw new Error('terminal nested error unexpectedly succeeded')
+    }
+  }
+
+  if (release) {
+    const releaseClient = new Client(
+      buildRpcStreamOpenStream('release', service.RpcStream.bind(service)),
+    )
+    let releaseFailed = false
+    const releaseService = new EchoerClient(releaseClient)
+    try {
+      await releaseService.Echo({ body: '__nested_release__' })
+    } catch (error) {
+      releaseFailed = true
+      requireError(error, 'release during active call', [
+        'closed before completion',
+        'stream closed',
+        'abort',
+        'cancel',
+      ])
+    }
+    if (!releaseFailed) {
+      throw new Error('release during active call unexpectedly succeeded')
+    }
+    const releaseStatus = await service.Echo({
+      body: '__nested_release_status__',
+    })
+    if (releaseStatus.body !== 'released') {
+      throw new Error(`release completion returned ${releaseStatus.body}`)
+    }
+    let releasedRejected = false
+    try {
+      await releaseService.Echo({})
+    } catch (error) {
+      releasedRejected = true
+      requireError(error, 'released component', ['unknown component: release'])
+    }
+    if (!releasedRejected) {
+      throw new Error('released component unexpectedly remained available')
+    }
+  }
+
+  const cancelled = new AbortController()
+  const cancelledStream = proxiedClient.bidirectionalStreamingRequest(
+    'echo.Echoer',
+    'EchoBidiStream',
+    (async function* () {
+      yield new Uint8Array()
+      await new Promise(() => undefined)
+    })(),
+    cancelled.signal,
+  )
+  const cancelledIterator = cancelledStream[Symbol.asyncIterator]()
+  const firstNestedResponse = await cancelledIterator.next()
+  if (firstNestedResponse.done) {
+    throw new Error('nested cancellation call ended before its first response')
+  }
+  cancelled.abort()
+  let cancelRejected = false
+  try {
+    while (!(await cancelledIterator.next()).done) {
+      // Drain until the abort reaches the nested call.
+    }
+  } catch (error) {
+    cancelRejected = true
+    requireError(error, 'nested cancellation', [ERR_RPC_ABORT])
+  }
+  if (!cancelRejected) {
+    throw new Error('nested cancellation unexpectedly completed normally')
+  }
 }

--- a/integration/cross-language/go-client/main.go
+++ b/integration/cross-language/go-client/main.go
@@ -6,19 +6,23 @@ import (
 	"io"
 	"net"
 	"os"
+	"strings"
 
 	"github.com/aperturerobotics/starpc/echo"
+	"github.com/aperturerobotics/starpc/rpcstream"
 	"github.com/aperturerobotics/starpc/srpc"
 )
 
 const bodyTxt = "hello world via starpc cross-language e2e test"
 
 func main() {
-	if len(os.Args) <= 1 {
-		fmt.Fprintf(os.Stderr, "usage: go-client <addr>\n")
+	nested := len(os.Args) >= 3 && os.Args[1] == "--nested"
+	nestedRelease := len(os.Args) >= 3 && os.Args[1] == "--nested-release"
+	if len(os.Args) != 2 && !nested && !nestedRelease {
+		fmt.Fprintf(os.Stderr, "usage: go-client [--nested] <addr>\n")
 		os.Exit(1)
 	}
-	addr := os.Args[1]
+	addr := os.Args[len(os.Args)-1]
 	openStream := func(ctx context.Context, msgHandler srpc.PacketDataHandler, closeHandler srpc.CloseHandler) (srpc.PacketWriter, error) {
 		conn, err := net.Dial("tcp", addr) //nolint:gosec
 		if err != nil {
@@ -47,6 +51,12 @@ func main() {
 	if err := testBidiStream(ctx, echoClient); err != nil {
 		fmt.Fprintf(os.Stderr, "bidi stream test failed: %v\n", err)
 		os.Exit(1)
+	}
+	if nested || nestedRelease {
+		if err := testNested(ctx, echoClient, nestedRelease); err != nil {
+			fmt.Fprintf(os.Stderr, "nested lifecycle test failed: %v\n", err)
+			os.Exit(1)
+		}
 	}
 	fmt.Println("All tests passed.")
 }
@@ -141,5 +151,71 @@ func testBidiStream(ctx context.Context, client echo.SRPCEchoerClient) error {
 	}
 	_ = strm.Close()
 	fmt.Println("  PASSED")
+	return nil
+}
+
+func testNested(ctx context.Context, parent echo.SRPCEchoerClient, release bool) error {
+	proxy := rpcstream.NewRpcStreamClient(parent.RpcStream, "test", true)
+	if err := testUnary(ctx, echo.NewSRPCEchoerClient(proxy)); err != nil {
+		return fmt.Errorf("nested unary: %w", err)
+	}
+
+	if release {
+		missing := rpcstream.NewRpcStreamClient(parent.RpcStream, "missing", true)
+		var missingOut echo.EchoMsg
+		if err := missing.ExecCall(ctx, "echo.Echoer", "Echo", &echo.EchoMsg{}, &missingOut); err == nil || !strings.Contains(err.Error(), "unknown component: missing") {
+			return fmt.Errorf("unknown component returned wrong result: %v", err)
+		}
+	}
+
+	stream, err := proxy.NewStream(ctx, "echo.Echoer", "EchoBidiStream", nil)
+	if err != nil {
+		return fmt.Errorf("nested bidi: %w", err)
+	}
+	if err := stream.MsgSend(&echo.EchoMsg{Body: "nested later data"}); err != nil {
+		return fmt.Errorf("nested later data: %w", err)
+	}
+	if err := stream.Close(); err != nil {
+		return fmt.Errorf("nested cancel: %w", err)
+	}
+
+	var terminal echo.EchoMsg
+	if err := proxy.ExecCall(ctx, "missing.Service", "Missing", &echo.EchoMsg{}, &terminal); err == nil || !strings.Contains(err.Error(), "missing.Service") {
+		return fmt.Errorf("unknown nested method returned wrong result: %v", err)
+	}
+
+	if release {
+		var terminalError echo.EchoMsg
+		if err := proxy.ExecCall(ctx, "echo.Echoer", "Echo", &echo.EchoMsg{Body: "__nested_error__"}, &terminalError); err == nil || !strings.Contains(err.Error(), "nested terminal error") {
+			return fmt.Errorf("terminal nested error returned wrong result: %v", err)
+		}
+	}
+
+	if release {
+		releaseClient := rpcstream.NewRpcStreamClient(parent.RpcStream, "release", true)
+		var released echo.EchoMsg
+		err := releaseClient.ExecCall(ctx, "echo.Echoer", "Echo", &echo.EchoMsg{Body: "__nested_release__"}, &released)
+		if err == nil || (!strings.Contains(err.Error(), "stream closed before the remote reported completion") && !strings.Contains(err.Error(), "EOF") && !strings.Contains(err.Error(), "canceled")) {
+			return fmt.Errorf("release during active call returned wrong result: %v", err)
+		}
+		status, err := parent.Echo(ctx, &echo.EchoMsg{Body: "__nested_release_status__"})
+		if err != nil {
+			return fmt.Errorf("release completion status failed: %w", err)
+		}
+		if status.GetBody() != "released" {
+			return fmt.Errorf("release completion returned %q", status.GetBody())
+		}
+		if err := releaseClient.ExecCall(ctx, "echo.Echoer", "Echo", &echo.EchoMsg{}, &released); err == nil || !strings.Contains(err.Error(), "unknown component: release") {
+			return fmt.Errorf("released component returned wrong result: %v", err)
+		}
+	}
+
+	direct, err := rpcstream.OpenRpcStream(ctx, parent.RpcStream, "test", true)
+	if err != nil {
+		return fmt.Errorf("nested direct open: %w", err)
+	}
+	if err := direct.Close(); err != nil {
+		return fmt.Errorf("nested abrupt close: %w", err)
+	}
 	return nil
 }

--- a/integration/cross-language/python-client.py
+++ b/integration/cross-language/python-client.py
@@ -18,9 +18,14 @@ from starpc.stream import open_tcp_stream
 
 
 async def main() -> None:
-    if len(sys.argv) != 2 or ":" not in sys.argv[1]:
-        raise ValueError("usage: python-client.py host:port")
-    host, port_text = sys.argv[1].rsplit(":", 1)
+    args = sys.argv[1:]
+    nested = args[:1] in (["--nested"], ["--nested-release"])
+    strict_nested = args[:1] == ["--nested-release"]
+    if nested:
+        args = args[1:]
+    if len(args) != 1 or ":" not in args[0]:
+        raise ValueError("usage: python-client.py [--nested] host:port")
+    host, port_text = args[0].rsplit(":", 1)
     port = int(port_text)
     raw_client = Client(lambda: open_tcp_stream(host, port))
     client = EchoerClient(raw_client)
@@ -76,7 +81,61 @@ async def main() -> None:
     except CallCancelledError:
         pass
     await cancelled.aclose()
+    if nested:
+        await run_nested_test(client, strict_nested)
     print("All tests passed.")
+
+
+async def run_nested_test(client: EchoerClient, strict: bool = False) -> None:
+    from starpc.rpcstream import (
+        RpcStreamRemoteError,
+        build_rpc_stream_open_stream,
+    )
+
+    nested_client = Client(build_rpc_stream_open_stream("test", client.rpc_stream))
+    nested_echo = EchoerClient(nested_client)
+    body = "hello world via nested python"
+    response = await nested_echo.echo(echo_pb2.EchoMsg(body=body))
+    if response.body != body:
+        raise RuntimeError(f"unexpected nested unary response: {response.body!r}")
+
+    if strict:
+        try:
+            await nested_echo.echo(echo_pb2.EchoMsg(body="__nested_error__"))
+        except RemoteCallError:
+            pass
+        else:
+            raise RuntimeError("terminal nested error unexpectedly succeeded")
+
+    if strict:
+        missing = Client(build_rpc_stream_open_stream("missing", client.rpc_stream))
+        try:
+            await missing.open_call("echo.Echoer", "Echo")
+        except RpcStreamRemoteError:
+            pass
+        else:
+            raise RuntimeError("unknown component unexpectedly succeeded")
+
+    terminal = await nested_client.open_call("missing.Service", "Missing")
+    try:
+        await terminal.receive()
+    except RemoteCallError:
+        pass
+    else:
+        raise RuntimeError("unknown nested method unexpectedly succeeded")
+    finally:
+        await terminal.aclose()
+
+    cancelled = await nested_client.open_call("echo.Echoer", "EchoBidiStream")
+    await cancelled.send(
+        echo_pb2.EchoMsg(body="nested later data").SerializeToString(deterministic=True)
+    )
+    await cancelled.cancel()
+    try:
+        await cancelled.wait_closed()
+    except CallCancelledError:
+        pass
+    await cancelled.aclose()
 
 
 async def _one_request(body: str) -> AsyncIterator[echo_pb2.EchoMsg]:

--- a/integration/cross-language/python-server.py
+++ b/integration/cross-language/python-server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 # The checkout supplies generated message packages outside the installed wheel.
 import asyncio
+import signal
 import sys
 from collections.abc import AsyncIterator
 from pathlib import Path
@@ -13,12 +14,39 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 from echo import echo_pb2
 from echo.echo_srpc import register_echoer
 from rpcstream import rpcstream_pb2
+from starpc.rpcstream import ComponentRegistry, handle_rpc_stream
 from starpc.server import Server, ServiceRegistry
 from starpc.stream import TCPStreamServer
 
 
 class Implementation:
+    def __init__(self, components: ComponentRegistry) -> None:
+        self._components = components
+        self._release_task: asyncio.Task[None] | None = None
+        self._release_complete = asyncio.Event()
+
+    async def _release_component(self) -> None:
+        try:
+            await self._components.unregister("release")
+        finally:
+            self._release_complete.set()
+
+    async def wait_for_release(self) -> None:
+        task = self._release_task
+        if task is not None:
+            await task
+
     async def echo(self, request: echo_pb2.EchoMsg) -> echo_pb2.EchoMsg:
+        if request.body == "__nested_error__":
+            raise RuntimeError("nested terminal error")
+        if request.body == "__nested_release__":
+            if self._release_task is None:
+                self._release_task = asyncio.create_task(self._release_component())
+            await asyncio.Future()
+        if request.body == "__nested_release_status__":
+            await self._release_complete.wait()
+            await self.wait_for_release()
+            return echo_pb2.EchoMsg(body="released")
         return echo_pb2.EchoMsg(body=request.body)
 
     async def echo_server_stream(
@@ -42,12 +70,10 @@ class Implementation:
         async for request in requests:
             yield request
 
-    async def rpc_stream(
+    def rpc_stream(
         self, requests: AsyncIterator[rpcstream_pb2.RpcStreamPacket]
     ) -> AsyncIterator[rpcstream_pb2.RpcStreamPacket]:
-        if False:
-            yield rpcstream_pb2.RpcStreamPacket()
-        raise NotImplementedError("nested RPC streams are not implemented")
+        return handle_rpc_stream(requests, self._components)
 
     async def do_nothing(self, request: empty_pb2.Empty) -> empty_pb2.Empty:
         return request
@@ -56,22 +82,42 @@ class Implementation:
 async def main() -> None:
     port = int(sys.argv[1]) if len(sys.argv) > 1 else 0
     registry = ServiceRegistry()
-    register_echoer(registry, Implementation())
+    components = ComponentRegistry()
+    await components.register("test", Server(registry))
+    await components.register("release", Server(registry))
+    implementation = Implementation(components)
+    register_echoer(registry, implementation)
     server = TCPStreamServer()
     await server.start("127.0.0.1", port)
     host, bound_port = server.address
     print(f"LISTENING {host}:{bound_port}", flush=True)
     rpc_server = Server(registry)
     tasks: set[asyncio.Task[None]] = set()
+    errors: list[BaseException] = []
+    stopping = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, stopping.set)
 
     def observe_task(task: asyncio.Task[None]) -> None:
         tasks.discard(task)
-        if not task.cancelled():
-            task.exception()
+        if not task.cancelled() and (error := task.exception()) is not None:
+            errors.append(error)
 
     try:
-        while True:
-            stream = await server.accept()
+        while not stopping.is_set():
+            accepting = asyncio.create_task(server.accept())
+            stopped = asyncio.create_task(stopping.wait())
+            done, _ = await asyncio.wait(
+                {accepting, stopped}, return_when=asyncio.FIRST_COMPLETED
+            )
+            if stopped in done:
+                accepting.cancel()
+                await asyncio.gather(accepting, return_exceptions=True)
+                break
+            stopped.cancel()
+            await asyncio.gather(stopped, return_exceptions=True)
+            stream = accepting.result()
             task = asyncio.create_task(rpc_server.serve(stream))
             tasks.add(task)
             task.add_done_callback(observe_task)
@@ -80,6 +126,14 @@ async def main() -> None:
         for task in tasks:
             task.cancel()
         await asyncio.gather(*tasks, return_exceptions=True)
+        await implementation.wait_for_release()
+        await components.unregister("test")
+        await components.unregister("release")
+        if errors:
+            raise ExceptionGroup("cross-language server tasks failed", errors)
+        if components._components or components._retired:
+            raise RuntimeError("nested component cleanup is incomplete")
+        print("NESTED_CLEAN", flush=True)
 
 
 if __name__ == "__main__":

--- a/integration/cross-language/run.bash
+++ b/integration/cross-language/run.bash
@@ -3,10 +3,11 @@
 # Runs all 21 server/client combinations across Go, TypeScript, Rust, C++, and Python.
 #
 # Usage:
-#   ./run.bash                # Run all pairs
-#   ./run.bash go:ts          # Run go-server+ts-client and ts-server+go-client
-#   ./run.bash python:go      # Run python-server+go-client and go-server+python-client
-#   ./run.bash go:ts python:ts # Run multiple pair filters
+#   ./run.bash                         # Run all pairs
+#   ./run.bash go:ts                   # Run go-server+ts-client and ts-server+go-client
+#   ./run.bash python:go               # Run python-server+go-client and go-server+python-client
+#   ./run.bash --nested ts:python      # Run nested TypeScript/Python pairs
+#   ./run.bash --nested go:ts go:python ts:python # Run nested Go/TypeScript/Python pairs
 set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -15,7 +16,15 @@ REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 # Fixes errors with the generated esm using require()
 ESM_BANNER='import{fileURLToPath}from"node:url";import{dirname}from"node:path";import{createRequire as topLevelCreateRequire}from"node:module";const require=topLevelCreateRequire(import.meta.url);const __filename=fileURLToPath(import.meta.url);const __dirname=dirname(__filename);'
 
-FILTERS=("$@")
+NESTED=false
+FILTERS=()
+for arg in "$@"; do
+    if [ "$arg" = "--nested" ]; then
+        NESTED=true
+    else
+        FILTERS+=("$arg")
+    fi
+done
 
 needs_language() {
     local language="$1"
@@ -36,6 +45,7 @@ ERRORS=""
 
 SERVER_PID=""
 SERVER_LOG=""
+SERVER_EXIT_STATUS=0
 CLIENT_PID=""
 CLIENT_OUT=""
 
@@ -161,8 +171,35 @@ start_server() {
 
 stop_server() {
     kill "$SERVER_PID" 2>/dev/null || true
-    wait "$SERVER_PID" 2>/dev/null || true
+    if wait "$SERVER_PID" 2>/dev/null; then
+        SERVER_EXIT_STATUS=0
+    else
+        SERVER_EXIT_STATUS=$?
+    fi
     SERVER_PID=""
+}
+
+python_server_passed() {
+    local status="$1"
+    local log="$2"
+    [ "$status" -eq 0 ] && grep -qx "NESTED_CLEAN" "$log"
+}
+
+verify_python_server_guard() {
+    local log
+    log="$(mktemp)"
+    printf '%s\n' "NESTED_CLEAN" >"$log"
+    if python_server_passed 1 "$log"; then
+        rm -f "$log"
+        echo "runner guard accepted a nonzero Python server" >&2
+        return 1
+    fi
+    if ! python_server_passed 0 "$log"; then
+        rm -f "$log"
+        echo "runner guard rejected a clean Python server" >&2
+        return 1
+    fi
+    rm -f "$log"
 }
 
 # run_pair <test_name> <server_args...> -- <client_args...>
@@ -200,13 +237,23 @@ run_pair() {
 
     CLIENT_OUT=$(mktemp)
     local client_ok=false
-    "${cli_args[@]}" "$SERVER_ADDR" > "$CLIENT_OUT" 2>&1 &
+    timeout 60 "${cli_args[@]}" "$SERVER_ADDR" > "$CLIENT_OUT" 2>&1 &
     CLIENT_PID=$!
     if wait "$CLIENT_PID"; then
         client_ok=true
     fi
     CLIENT_PID=""
     stop_server
+    if $NESTED && [[ "$test_name" == python-server* ]]; then
+        if ! verify_python_server_guard; then
+            client_ok=false
+            echo "    Python server result guard regression failed"
+        elif ! python_server_passed "$SERVER_EXIT_STATUS" "$SERVER_LOG"; then
+            client_ok=false
+            echo "    Python server failed nested shutdown (status $SERVER_EXIT_STATUS):"
+            sed 's/^/    /' "$SERVER_LOG"
+        fi
+    fi
 
     if $client_ok; then
         echo "PASSED"
@@ -227,36 +274,48 @@ echo ""
 echo "=== Running cross-language integration tests ==="
 echo ""
 
-# Go server combinations
-run_pair "go-server + go-client"   "$GO_SERVER" -- "$GO_CLIENT"
-run_pair "go-server + rust-client" "$GO_SERVER" -- "$RUST_CLIENT"
-run_pair "go-server + ts-client"   "$GO_SERVER" -- node "$TS_CLIENT"
-run_pair "go-server + cpp-client"    "$GO_SERVER" -- "$CPP_CLIENT"
-run_pair "go-server + python-client" "$GO_SERVER" -- "${PYTHON[@]}" "$SCRIPT_DIR/python-client.py"
+if $NESTED; then
+    # Nested streams have maintained Go, TypeScript, and Python endpoints.
+    run_pair "go-server + ts-client" "$GO_SERVER" -- node "$TS_CLIENT" --nested
+    run_pair "go-server + python-client" "$GO_SERVER" -- "${PYTHON[@]}" "$SCRIPT_DIR/python-client.py" --nested
 
-# Rust server combinations
-run_pair "rust-server + go-client"   "$RUST_SERVER" -- "$GO_CLIENT"
-run_pair "rust-server + rust-client" "$RUST_SERVER" -- "$RUST_CLIENT"
-run_pair "rust-server + ts-client"   "$RUST_SERVER" -- node "$TS_CLIENT"
-run_pair "rust-server + cpp-client"  "$RUST_SERVER" -- "$CPP_CLIENT"
+    run_pair "ts-server + go-client" node "$TS_SERVER" -- "$GO_CLIENT" --nested
+    run_pair "ts-server + python-client" node "$TS_SERVER" -- "${PYTHON[@]}" "$SCRIPT_DIR/python-client.py" --nested
 
-# TypeScript server combinations
-run_pair "ts-server + go-client"   node "$TS_SERVER" -- "$GO_CLIENT"
-run_pair "ts-server + rust-client" node "$TS_SERVER" -- "$RUST_CLIENT"
-run_pair "ts-server + ts-client"   node "$TS_SERVER" -- node "$TS_CLIENT"
-run_pair "ts-server + cpp-client"    node "$TS_SERVER" -- "$CPP_CLIENT"
-run_pair "ts-server + python-client" node "$TS_SERVER" -- "${PYTHON[@]}" "$SCRIPT_DIR/python-client.py"
+    run_pair "python-server + go-client" "${PYTHON[@]}" "$SCRIPT_DIR/python-server.py" -- "$GO_CLIENT" --nested-release
+    run_pair "python-server + ts-client" "${PYTHON[@]}" "$SCRIPT_DIR/python-server.py" -- node "$TS_CLIENT" --nested-release
+else
+    # Go server combinations
+    run_pair "go-server + go-client"   "$GO_SERVER" -- "$GO_CLIENT"
+    run_pair "go-server + rust-client" "$GO_SERVER" -- "$RUST_CLIENT"
+    run_pair "go-server + ts-client"   "$GO_SERVER" -- node "$TS_CLIENT"
+    run_pair "go-server + cpp-client"    "$GO_SERVER" -- "$CPP_CLIENT"
+    run_pair "go-server + python-client" "$GO_SERVER" -- "${PYTHON[@]}" "$SCRIPT_DIR/python-client.py"
 
-# Python server combinations
-run_pair "python-server + go-client"     "${PYTHON[@]}" "$SCRIPT_DIR/python-server.py" -- "$GO_CLIENT"
-run_pair "python-server + ts-client"     "${PYTHON[@]}" "$SCRIPT_DIR/python-server.py" -- node "$TS_CLIENT" lifecycle
-run_pair "python-server + python-client" "${PYTHON[@]}" "$SCRIPT_DIR/python-server.py" -- "${PYTHON[@]}" "$SCRIPT_DIR/python-client.py"
+    # Rust server combinations
+    run_pair "rust-server + go-client"   "$RUST_SERVER" -- "$GO_CLIENT"
+    run_pair "rust-server + rust-client" "$RUST_SERVER" -- "$RUST_CLIENT"
+    run_pair "rust-server + ts-client"   "$RUST_SERVER" -- node "$TS_CLIENT"
+    run_pair "rust-server + cpp-client"  "$RUST_SERVER" -- "$CPP_CLIENT"
 
-# C++ server combinations
-run_pair "cpp-server + go-client"   "$CPP_SERVER" -- "$GO_CLIENT"
-run_pair "cpp-server + rust-client" "$CPP_SERVER" -- "$RUST_CLIENT"
-run_pair "cpp-server + ts-client"   "$CPP_SERVER" -- node "$TS_CLIENT"
-run_pair "cpp-server + cpp-client"  "$CPP_SERVER" -- "$CPP_CLIENT"
+    # TypeScript server combinations
+    run_pair "ts-server + go-client"   node "$TS_SERVER" -- "$GO_CLIENT"
+    run_pair "ts-server + rust-client" node "$TS_SERVER" -- "$RUST_CLIENT"
+    run_pair "ts-server + ts-client"   node "$TS_SERVER" -- node "$TS_CLIENT"
+    run_pair "ts-server + cpp-client"    node "$TS_SERVER" -- "$CPP_CLIENT"
+    run_pair "ts-server + python-client" node "$TS_SERVER" -- "${PYTHON[@]}" "$SCRIPT_DIR/python-client.py"
+
+    # Python server combinations
+    run_pair "python-server + go-client"     "${PYTHON[@]}" "$SCRIPT_DIR/python-server.py" -- "$GO_CLIENT"
+    run_pair "python-server + ts-client"     "${PYTHON[@]}" "$SCRIPT_DIR/python-server.py" -- node "$TS_CLIENT" lifecycle
+    run_pair "python-server + python-client" "${PYTHON[@]}" "$SCRIPT_DIR/python-server.py" -- "${PYTHON[@]}" "$SCRIPT_DIR/python-client.py"
+
+    # C++ server combinations
+    run_pair "cpp-server + go-client"   "$CPP_SERVER" -- "$GO_CLIENT"
+    run_pair "cpp-server + rust-client" "$CPP_SERVER" -- "$RUST_CLIENT"
+    run_pair "cpp-server + ts-client"   "$CPP_SERVER" -- node "$TS_CLIENT"
+    run_pair "cpp-server + cpp-client"  "$CPP_SERVER" -- "$CPP_CLIENT"
+fi
 
 echo ""
 echo "=== Results: ${PASSED} passed, ${FAILED} failed ==="

--- a/integration/cross-language/ts-client.ts
+++ b/integration/cross-language/ts-client.ts
@@ -10,6 +10,7 @@ import { combineUint8ArrayListTransform } from '../../srpc/array-list.js'
 import {
   runClientTest,
   runAbortControllerTest,
+  runRpcStreamTest,
 } from '../../echo/client-test.js'
 import { EchoerClient } from '../../echo/echo_srpc.pb.js'
 import type { OpenStreamFunc, PacketStream } from '../../srpc/stream.js'
@@ -91,9 +92,16 @@ function parseAddr(addr: string): { host: string; port: number } {
 async function main() {
   const args = process.argv.slice(2)
   const lifecycle = args.includes('lifecycle')
-  const addr = args.find((arg) => arg !== 'lifecycle')
+  const nested = args.includes('--nested') || args.includes('--nested-release')
+  const nestedRelease = args.includes('--nested-release')
+  const addr = args.find(
+    (arg) =>
+      arg !== 'lifecycle' && arg !== '--nested' && arg !== '--nested-release',
+  )
   if (!addr) {
-    console.error('usage: ts-client [lifecycle] <host:port>')
+    console.error(
+      'usage: ts-client [--nested] [--nested-release] [lifecycle] <host:port>',
+    )
     process.exit(1)
   }
 
@@ -115,6 +123,10 @@ async function main() {
   if (lifecycle) {
     console.log('Running abort controller test via TCP...')
     await runAbortControllerTest(client)
+  }
+  if (nested) {
+    console.log('Running RpcStream test via TCP...')
+    await runRpcStreamTest(client, nestedRelease)
   }
   console.log('All tests passed.')
 }

--- a/python/README.md
+++ b/python/README.md
@@ -19,3 +19,36 @@ bun run gen
 Do not use a system `protoc` or copy generated files from another checkout.
 The repository command formats generated Python and existing-language outputs
 and is deterministic across repeated runs.
+
+## Nested RPC streams
+
+Register a component with a bounded inner server, then expose its stream method:
+
+```python
+from starpc.client import Client
+from starpc.rpcstream import (
+    ComponentRegistry,
+    build_rpc_stream_open_stream,
+    handle_rpc_stream,
+)
+from starpc.server import Server
+
+components = ComponentRegistry()
+await components.register("worker", Server(registry))
+
+def rpc_stream(requests):
+    return handle_rpc_stream(requests, components)
+```
+
+A client opens the acknowledged component stream with the existing StarPC
+client owner:
+
+```python
+open_stream = build_rpc_stream_open_stream("worker", caller)
+client = Client(open_stream)
+```
+
+`caller` accepts and returns an async iterable of `RpcStreamPacket` messages;
+`handle_rpc_stream` performs the `Init`/`Ack` handshake and proxies embedded
+StarPC packets. Unregistering a component waits for active nested routes to
+finish before its release callback runs.

--- a/python/tests/test_rpcstream.py
+++ b/python/tests/test_rpcstream.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import unittest
+from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable
+
+from rpcstream import rpcstream_pb2
+from srpc import rpcproto_pb2
+from starpc.call import Call, CallCancelledError, CallError, RemoteCallError
+from starpc.client import Client
+from starpc.rpcstream import (
+    ComponentRegistry,
+    RpcStreamProtocolError,
+    RpcStreamRemoteError,
+    build_rpc_stream_open_stream,
+    handle_rpc_stream,
+)
+from starpc.server import Handler, Server, ServiceRegistry
+from starpc.stream import ByteStream
+
+
+class RpcStreamContractTest(unittest.TestCase):
+    def test_build_rpc_stream_open_stream_is_public(self) -> None:
+        self.assertTrue(callable(build_rpc_stream_open_stream))
+
+
+class RpcStreamTest(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.components = ComponentRegistry(capacity_bytes=64)
+
+    async def asyncTearDown(self) -> None:
+        for component_id in tuple(self.components._components):
+            await asyncio.wait_for(self.components.unregister(component_id), 1)
+        self.assertFalse(self.components._retired)
+
+    def client(
+        self,
+        component_id: str = "test",
+        seen: list[rpcstream_pb2.RpcStreamPacket] | None = None,
+    ) -> Client:
+        async def caller(
+            requests: AsyncIterable[rpcstream_pb2.RpcStreamPacket],
+        ) -> AsyncIterator[rpcstream_pb2.RpcStreamPacket]:
+            async def recorded() -> AsyncIterator[rpcstream_pb2.RpcStreamPacket]:
+                async for request in requests:
+                    if seen is not None:
+                        seen.append(request)
+                    yield request
+
+            async for response in handle_rpc_stream(recorded(), self.components):
+                yield response
+
+        return Client(
+            build_rpc_stream_open_stream(component_id, caller, capacity_bytes=64),
+            inbound_capacity=1,
+        )
+
+    async def register(
+        self,
+        handler: Handler,
+        component_id: str = "test",
+        on_release: Callable[[], Awaitable[None] | None] | None = None,
+    ) -> None:
+        services = ServiceRegistry()
+        services.register("test.Service", "Do", handler)
+        await self.components.register(
+            component_id, Server(services, inbound_capacity=1), on_release
+        )
+
+    async def test_acknowledged_unary_uses_unframed_outer_packets(self) -> None:
+        released = asyncio.Event()
+        seen: list[rpcstream_pb2.RpcStreamPacket] = []
+
+        async def handler(call: Call) -> None:
+            self.assertEqual(await call.receive(), b"request")
+            await call.finish(b"response")
+
+        await self.register(handler, on_release=released.set)
+        call = await self.client(seen=seen).open_call("test.Service", "Do", b"request")
+        self.assertEqual(await call.receive(), b"response")
+        self.assertIsNone(await call.receive())
+        await call.aclose()
+        await asyncio.wait_for(released.wait(), 1)
+
+        self.assertEqual(seen[0].WhichOneof("body"), "init")
+        self.assertEqual(seen[0].init.component_id, "test")
+        self.assertEqual(seen[1].WhichOneof("body"), "data")
+        inner = rpcproto_pb2.Packet.FromString(seen[1].data)
+        self.assertEqual(inner.WhichOneof("body"), "call_start")
+        self.assertEqual(inner.call_start.rpc_service, "test.Service")
+        self.assertEqual(inner.call_start.rpc_method, "Do")
+        self.assertEqual(
+            seen[1].data,
+            inner.SerializeToString(deterministic=True),
+        )
+        self.assertFalse(self.components._components["test"].routes)
+
+    async def test_closing_after_ack_releases_route_once(self) -> None:
+        releases: list[None] = []
+
+        async def requests() -> AsyncIterator[rpcstream_pb2.RpcStreamPacket]:
+            yield rpcstream_pb2.RpcStreamPacket(
+                init=rpcstream_pb2.RpcStreamInit(component_id="test")
+            )
+
+        await self.register(
+            lambda _call: asyncio.sleep(0), on_release=lambda: releases.append(None)
+        )
+        nested = handle_rpc_stream(requests(), self.components)
+        self.assertEqual((await anext(nested)).WhichOneof("body"), "ack")
+        await nested.aclose()
+        self.assertEqual(releases, [None])
+        self.assertFalse(self.components._components["test"].routes)
+        await asyncio.wait_for(self.components.unregister("test"), 1)
+        self.assertFalse(self.components._retired)
+
+    async def test_open_waits_for_acknowledgement(self) -> None:
+        seen_init = asyncio.Event()
+        release_ack = asyncio.Event()
+
+        async def caller(
+            requests: AsyncIterable[rpcstream_pb2.RpcStreamPacket],
+        ) -> AsyncIterator[rpcstream_pb2.RpcStreamPacket]:
+            request = await anext(requests.__aiter__())
+            self.assertEqual(request.WhichOneof("body"), "init")
+            seen_init.set()
+            await release_ack.wait()
+            yield rpcstream_pb2.RpcStreamPacket(ack=rpcstream_pb2.RpcAck())
+
+        opener = build_rpc_stream_open_stream("test", caller)
+
+        async def open_stream() -> ByteStream:
+            return await opener()
+
+        opening: asyncio.Task[ByteStream] = asyncio.create_task(open_stream())
+        await asyncio.wait_for(seen_init.wait(), 1)
+        self.assertFalse(opening.done())
+        release_ack.set()
+        stream = await asyncio.wait_for(opening, 1)
+        await stream.aclose()
+
+    async def test_unknown_component_is_rejected_in_ack(self) -> None:
+        async def caller(
+            requests: AsyncIterable[rpcstream_pb2.RpcStreamPacket],
+        ) -> AsyncIterator[rpcstream_pb2.RpcStreamPacket]:
+            async for response in handle_rpc_stream(
+                requests.__aiter__(), self.components
+            ):
+                yield response
+
+        client = Client(build_rpc_stream_open_stream("missing", caller))
+        with self.assertRaisesRegex(RpcStreamRemoteError, "unknown component"):
+            await client.open_call("test.Service", "Do")
+        self.assertFalse(self.components._components)
+
+    async def test_later_data_and_cancel_settle_the_route_once(self) -> None:
+        handler_done = asyncio.Event()
+        released = asyncio.Event()
+        seen: list[rpcstream_pb2.RpcStreamPacket] = []
+
+        async def handler(call: Call) -> None:
+            try:
+                self.assertEqual(await call.receive(), b"later")
+                await asyncio.Future()
+            finally:
+                handler_done.set()
+
+        await self.register(handler, on_release=released.set)
+        call = await self.client(seen=seen).open_call("test.Service", "Do")
+        await call.send(b"later")
+        await call.cancel()
+        with self.assertRaises(CallCancelledError):
+            await call.wait_closed()
+        await call.aclose()
+        await asyncio.wait_for(handler_done.wait(), 1)
+        await asyncio.wait_for(released.wait(), 1)
+
+        bodies = [
+            rpcproto_pb2.Packet.FromString(packet.data).WhichOneof("body")
+            for packet in seen
+            if packet.WhichOneof("body") == "data"
+        ]
+        self.assertEqual(bodies, ["call_start", "call_data", "call_cancel"])
+        self.assertFalse(self.components._components["test"].routes)
+
+    async def test_terminal_handler_error_releases_after_server_settles(self) -> None:
+        released = asyncio.Event()
+
+        async def handler(call: Call) -> None:
+            raise RuntimeError("handler failed")
+
+        await self.register(handler, on_release=released.set)
+        call = await self.client().open_call("test.Service", "Do")
+        with self.assertRaisesRegex(RemoteCallError, "handler failed"):
+            await call.receive()
+        await call.aclose()
+        await asyncio.wait_for(released.wait(), 1)
+        self.assertFalse(self.components._components["test"].routes)
+
+    async def test_unregister_removes_before_cancellation_and_waits_for_handler(
+        self,
+    ) -> None:
+        handler_started = asyncio.Event()
+        cleanup_started = asyncio.Event()
+        release_cleanup = asyncio.Event()
+        handler_done = asyncio.Event()
+        release_count = 0
+
+        async def handler(call: Call) -> None:
+            handler_started.set()
+            try:
+                await asyncio.Future()
+            finally:
+                cleanup_started.set()
+                await release_cleanup.wait()
+                handler_done.set()
+
+        def on_release() -> None:
+            nonlocal release_count
+            self.assertTrue(handler_done.is_set())
+            release_count += 1
+
+        await self.register(handler, on_release=on_release)
+        call = await self.client().open_call("test.Service", "Do")
+        await asyncio.wait_for(handler_started.wait(), 1)
+        unregistering = asyncio.create_task(self.components.unregister("test"))
+        joined = asyncio.create_task(self.components.unregister("test"))
+        await asyncio.wait_for(cleanup_started.wait(), 1)
+        self.assertNotIn("test", self.components._components)
+        with self.assertRaises(RpcStreamRemoteError):
+            await self.client().open_call("test.Service", "Do")
+        with self.assertRaises(ValueError):
+            await self.components.register("test", Server(ServiceRegistry()))
+        self.assertFalse(unregistering.done())
+        self.assertFalse(joined.done())
+
+        release_cleanup.set()
+        await asyncio.wait_for(asyncio.gather(unregistering, joined), 1)
+        self.assertEqual(release_count, 1)
+        self.assertTrue(handler_done.is_set())
+        self.assertNotIn("test", self.components._retired)
+        await self.register(handler)
+        self.assertIn("test", self.components._components)
+        await self.components.unregister("test")
+        self.assertNotIn("test", self.components._retired)
+        with contextlib.suppress(CallError):
+            await call.wait_closed()
+        await call.aclose()
+
+    async def test_abrupt_close_releases_active_handler(self) -> None:
+        handler_done = asyncio.Event()
+        released = asyncio.Event()
+
+        async def handler(call: Call) -> None:
+            try:
+                await asyncio.Future()
+            finally:
+                handler_done.set()
+
+        await self.register(handler, on_release=released.set)
+        call = await self.client().open_call("test.Service", "Do")
+        await call.aclose()
+        await asyncio.wait_for(handler_done.wait(), 1)
+        await asyncio.wait_for(released.wait(), 1)
+        self.assertFalse(self.components._components["test"].routes)
+
+    async def test_unregister_unblocks_backpressured_input(self) -> None:
+        handler_started = asyncio.Event()
+        handler_done = asyncio.Event()
+        released = asyncio.Event()
+
+        async def handler(call: Call) -> None:
+            handler_started.set()
+            try:
+                await asyncio.Future()
+            finally:
+                handler_done.set()
+
+        await self.register(handler, on_release=released.set)
+        call = await self.client().open_call("test.Service", "Do")
+        await asyncio.wait_for(handler_started.wait(), 1)
+        sends = [asyncio.create_task(call.send(b"x" * 64)) for _ in range(8)]
+        await asyncio.sleep(0)
+        self.assertTrue(any(not send.done() for send in sends))
+        await asyncio.wait_for(self.components.unregister("test"), 1)
+        await asyncio.gather(*sends, return_exceptions=True)
+        self.assertTrue(all(send.done() for send in sends))
+        await asyncio.wait_for(handler_done.wait(), 1)
+        await asyncio.wait_for(released.wait(), 1)
+        await call.aclose()
+
+    async def test_unregister_unblocks_backpressured_output(self) -> None:
+        handler_started = asyncio.Event()
+        handler_finished = asyncio.Event()
+        released = asyncio.Event()
+
+        async def handler(call: Call) -> None:
+            handler_started.set()
+            try:
+                for _ in range(16):
+                    await call.send(b"x" * 64)
+                handler_finished.set()
+            finally:
+                pass
+
+        await self.register(handler, on_release=released.set)
+        call = await self.client().open_call("test.Service", "Do")
+        await asyncio.wait_for(handler_started.wait(), 1)
+        await asyncio.sleep(0)
+        self.assertFalse(handler_finished.is_set())
+        await asyncio.wait_for(self.components.unregister("test"), 1)
+        await asyncio.wait_for(released.wait(), 1)
+        self.assertNotIn("test", self.components._retired)
+        await call.aclose()
+
+    async def test_malformed_post_ack_input_propagates_after_route_cleanup(
+        self,
+    ) -> None:
+        releases: list[None] = []
+        await self.register(
+            lambda _call: asyncio.sleep(0), on_release=lambda: releases.append(None)
+        )
+
+        async def requests() -> AsyncIterator[rpcstream_pb2.RpcStreamPacket]:
+            yield rpcstream_pb2.RpcStreamPacket(
+                init=rpcstream_pb2.RpcStreamInit(component_id="test")
+            )
+            yield rpcstream_pb2.RpcStreamPacket(data=b"not-a-packet")
+
+        nested = handle_rpc_stream(requests(), self.components)
+        self.assertEqual((await anext(nested)).WhichOneof("body"), "ack")
+        with self.assertRaises(RpcStreamProtocolError):
+            await anext(nested)
+        self.assertEqual(releases, [None])
+        self.assertFalse(self.components._components["test"].routes)
+        self.assertFalse(self.components._retired)
+
+    async def test_invalid_inner_packet_releases_route_without_tasks(self) -> None:
+        releases: list[None] = []
+        await self.register(
+            lambda _call: asyncio.sleep(0), on_release=lambda: releases.append(None)
+        )
+
+        async def requests() -> AsyncIterator[rpcstream_pb2.RpcStreamPacket]:
+            yield rpcstream_pb2.RpcStreamPacket(
+                init=rpcstream_pb2.RpcStreamInit(component_id="test")
+            )
+            yield rpcstream_pb2.RpcStreamPacket(data=b"\x80")
+
+        nested = handle_rpc_stream(requests(), self.components)
+        await anext(nested)
+        with self.assertRaises(RpcStreamProtocolError):
+            await anext(nested)
+        self.assertEqual(releases, [None])
+        self.assertFalse(self.components._components["test"].routes)
+
+    async def test_partial_inner_frame_is_rejected_at_eof(self) -> None:
+        failure: asyncio.Future[RpcStreamProtocolError] = (
+            asyncio.get_running_loop().create_future()
+        )
+
+        async def caller(
+            requests: AsyncIterable[rpcstream_pb2.RpcStreamPacket],
+        ) -> AsyncIterator[rpcstream_pb2.RpcStreamPacket]:
+            iterator = requests.__aiter__()
+            request = await anext(iterator)
+            self.assertEqual(request.WhichOneof("body"), "init")
+            yield rpcstream_pb2.RpcStreamPacket(ack=rpcstream_pb2.RpcAck())
+            try:
+                async for _ in iterator:
+                    pass
+            except RpcStreamProtocolError as exc:
+                failure.set_result(exc)
+
+        stream = await build_rpc_stream_open_stream("test", caller)()
+        await stream.write(b"\x01\x00")
+        await stream.write_eof()
+        error = await asyncio.wait_for(failure, 1)
+        self.assertIsInstance(error, RpcStreamProtocolError)
+        await stream.aclose()

--- a/python/tests/test_server.py
+++ b/python/tests/test_server.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import asyncio
+import unittest
+
+from starpc.call import Call
+from starpc.server import Server, ServiceRegistry
+from starpc.stream import memory_stream_pair
+
+
+class ServerTest(unittest.IsolatedAsyncioTestCase):
+    async def test_cancelled_serve_retrieves_finished_handler_task(self) -> None:
+        client_stream, server_stream = memory_stream_pair(1024)
+        handler_started = asyncio.Event()
+        serve_task: asyncio.Task[None] | None = None
+        loop = asyncio.get_running_loop()
+        unhandled: list[dict[str, object]] = []
+        previous_handler = loop.get_exception_handler()
+        loop.set_exception_handler(lambda _loop, context: unhandled.append(context))
+
+        async def handler(_call: Call) -> None:
+            handler_started.set()
+            assert serve_task is not None
+            loop.call_soon(serve_task.cancel)
+            raise RuntimeError("handler failed")
+
+        registry = ServiceRegistry()
+        registry.register("test.Service", "Do", handler)
+        server = Server(registry)
+        client_call: Call | None = None
+        try:
+            client_call = await Call.open(client_stream, "test.Service", "Do")
+            serve_task = asyncio.create_task(server.serve(server_stream))
+            await asyncio.wait_for(handler_started.wait(), 1)
+            with self.assertRaises(asyncio.CancelledError):
+                await serve_task
+            await asyncio.sleep(0)
+            self.assertEqual(unhandled, [])
+        finally:
+            loop.set_exception_handler(previous_handler)
+            if client_call is not None:
+                await client_call.aclose()
+            await client_stream.aclose()
+            await server_stream.aclose()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/starpc/rpcstream.py
+++ b/starpc/rpcstream.py
@@ -1,0 +1,425 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import (
+    AsyncGenerator,
+    AsyncIterable,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+)
+from dataclasses import dataclass, field
+from typing import TypeAlias
+
+from google.protobuf.message import DecodeError
+
+from rpcstream import rpcstream_pb2
+from srpc import rpcproto_pb2
+from starpc.call import CallError
+from starpc.codec import (
+    CodecError,
+    PacketDecoder,
+    WriteCountError,
+    ZeroProgressError,
+    encode_packet,
+)
+from starpc.server import Server
+from starpc.stream import ByteStream, StreamClosedError, memory_stream_pair
+
+DEFAULT_INNER_CAPACITY = 65_536
+
+
+class RpcStreamError(Exception):
+    """Base class for nested RPC stream failures."""
+
+
+class RpcStreamProtocolError(RpcStreamError):
+    """The peer sent an invalid nested RPC stream packet."""
+
+
+class RpcStreamRemoteError(RpcStreamError):
+    """The remote endpoint rejected a nested RPC stream."""
+
+
+class ComponentNotFoundError(RpcStreamError):
+    """The requested component is not registered."""
+
+
+RpcStreamCaller: TypeAlias = Callable[
+    [AsyncIterable[rpcstream_pb2.RpcStreamPacket]],
+    AsyncIterator[rpcstream_pb2.RpcStreamPacket],
+]
+LeaseRelease: TypeAlias = Callable[[], Awaitable[None] | None]
+
+
+async def _write_all(stream: ByteStream, data: bytes) -> None:
+    offset = 0
+    while offset < len(data):
+        remaining = len(data) - offset
+        written = await stream.write(data[offset:])
+        if written <= 0:
+            raise ZeroProgressError("writer made no progress")
+        if written > remaining:
+            raise WriteCountError("writer exceeded supplied bytes")
+        offset += written
+
+
+def _frame_inner_packet(data: bytes) -> bytes:
+    try:
+        packet = rpcproto_pb2.Packet.FromString(data)
+    except DecodeError as exc:
+        raise RpcStreamProtocolError("malformed nested packet") from exc
+    try:
+        return encode_packet(packet)
+    except CodecError as exc:
+        raise RpcStreamProtocolError("invalid nested packet") from exc
+
+
+def _unframe_inner_packet(packet: rpcproto_pb2.Packet) -> rpcstream_pb2.RpcStreamPacket:
+    return rpcstream_pb2.RpcStreamPacket(
+        data=packet.SerializeToString(deterministic=True)
+    )
+
+
+class _ClientStream:
+    def __init__(
+        self,
+        stream: ByteStream,
+        peer: ByteStream,
+        responses: asyncio.Task[None],
+    ) -> None:
+        self._stream = stream
+        self._peer = peer
+        self._responses = responses
+        self._closed = False
+        self._close_lock = asyncio.Lock()
+
+    async def read(self, max_bytes: int) -> bytes:
+        return await self._stream.read(max_bytes)
+
+    async def write(self, data: bytes) -> int:
+        return await self._stream.write(data)
+
+    async def write_eof(self) -> None:
+        await self._stream.write_eof()
+
+    async def aclose(self) -> None:
+        async with self._close_lock:
+            if self._closed:
+                return
+            self._closed = True
+            await self._stream.aclose()
+            await self._peer.aclose()
+            if not self._responses.done():
+                self._responses.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await self._responses
+
+
+async def _open_rpc_stream(
+    component_id: str,
+    caller: RpcStreamCaller,
+    capacity_bytes: int,
+) -> ByteStream:
+    stream, peer = memory_stream_pair(capacity_bytes)
+    acknowledged = asyncio.Event()
+
+    async def requests() -> AsyncIterator[rpcstream_pb2.RpcStreamPacket]:
+        yield rpcstream_pb2.RpcStreamPacket(
+            init=rpcstream_pb2.RpcStreamInit(component_id=component_id)
+        )
+        await acknowledged.wait()
+        decoder = PacketDecoder()
+        try:
+            while True:
+                data = await peer.read(65_536)
+                if not data:
+                    decoder.finish()
+                    return
+                for packet in decoder.feed(data):
+                    yield _unframe_inner_packet(packet)
+        except StreamClosedError:
+            return
+        except CodecError as exc:
+            raise RpcStreamProtocolError("truncated nested packet") from exc
+
+    responses = caller(requests()).__aiter__()
+    try:
+        first = await anext(responses)
+        if first.WhichOneof("body") != "ack":
+            raise RpcStreamProtocolError("expected nested stream acknowledgement")
+        if first.ack.error:
+            raise RpcStreamRemoteError(first.ack.error)
+        acknowledged.set()
+
+        async def copy_responses() -> None:
+            try:
+                async for response in responses:
+                    if response.WhichOneof("body") != "data":
+                        raise RpcStreamProtocolError("unexpected nested stream packet")
+                    await _write_all(peer, _frame_inner_packet(bytes(response.data)))
+                await peer.write_eof()
+            except StreamClosedError:
+                await peer.aclose()
+            except BaseException:
+                await peer.aclose()
+                raise
+
+        response_task = asyncio.create_task(copy_responses())
+        return _ClientStream(stream, peer, response_task)
+    except BaseException:
+        await stream.aclose()
+        await peer.aclose()
+        if isinstance(responses, AsyncGenerator):
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await responses.aclose()
+        raise
+
+
+def build_rpc_stream_open_stream(
+    component_id: str,
+    caller: RpcStreamCaller,
+    capacity_bytes: int = DEFAULT_INNER_CAPACITY,
+) -> Callable[[], Awaitable[ByteStream]]:
+    """Build an opener that sends one acknowledged nested stream per inner call."""
+    if not component_id:
+        raise ValueError("component ID is required")
+    if capacity_bytes <= 0:
+        raise ValueError("capacity_bytes must be positive")
+
+    async def open_stream() -> ByteStream:
+        return await _open_rpc_stream(component_id, caller, capacity_bytes)
+
+    return open_stream
+
+
+@dataclass
+class _Component:
+    server: Server
+    on_release: LeaseRelease | None
+    routes: set[_ServerRoute] = field(default_factory=set)
+    drained: asyncio.Event = field(default_factory=asyncio.Event)
+    closing: bool = False
+
+    def __post_init__(self) -> None:
+        self.drained.set()
+
+
+class ComponentRegistry:
+    """Route named nested streams to registered inner StarPC servers."""
+
+    def __init__(self, capacity_bytes: int = DEFAULT_INNER_CAPACITY) -> None:
+        if capacity_bytes <= 0:
+            raise ValueError("capacity_bytes must be positive")
+        self._capacity_bytes = capacity_bytes
+        self._components: dict[str, _Component] = {}
+        self._retired: dict[str, _Component] = {}
+        self._lock = asyncio.Lock()
+
+    async def register(
+        self,
+        component_id: str,
+        server: Server,
+        on_release: LeaseRelease | None = None,
+    ) -> None:
+        """Register one component ID before it accepts nested streams."""
+        if not component_id:
+            raise ValueError("component ID is required")
+        async with self._lock:
+            if component_id in self._components or component_id in self._retired:
+                raise ValueError("component ID is already registered")
+            self._components[component_id] = _Component(server, on_release)
+
+    async def unregister(self, component_id: str) -> None:
+        """Invalidate one component and wait for every acquired route to settle."""
+        async with self._lock:
+            component = self._components.pop(component_id, None)
+            if component is not None:
+                component.closing = True
+                self._retired[component_id] = component
+            else:
+                component = self._retired.get(component_id)
+            if component is None:
+                return
+            routes = tuple(component.routes)
+
+        for route in routes:
+            await route.cancel()
+        await component.drained.wait()
+        async with self._lock:
+            if self._retired.get(component_id) is component:
+                del self._retired[component_id]
+
+    async def _acquire(self, component_id: str) -> _ServerRoute:
+        async with self._lock:
+            component = self._components.get(component_id)
+            if component is None or component.closing:
+                raise ComponentNotFoundError(f"unknown component: {component_id}")
+            route = _ServerRoute(
+                component.server, component.on_release, self._capacity_bytes
+            )
+            component.routes.add(route)
+            component.drained.clear()
+            route._component = component
+            return route
+
+    async def _release(self, route: _ServerRoute) -> None:
+        component = route._component
+        if component is None:
+            return
+        async with self._lock:
+            component.routes.discard(route)
+            if not component.routes:
+                component.drained.set()
+
+
+class _ServerRoute:
+    def __init__(
+        self,
+        server: Server,
+        on_release: LeaseRelease | None,
+        capacity_bytes: int,
+    ) -> None:
+        self._server = server
+        self._on_release = on_release
+        self._client, self._server_stream = memory_stream_pair(capacity_bytes)
+        self._component: _Component | None = None
+        self._input_task: asyncio.Task[None] | None = None
+        self._server_task: asyncio.Task[None] | None = None
+        self._closed = False
+        self._cancelled = False
+        self._released = False
+        self._failure: BaseException | None = None
+        self._close_lock = asyncio.Lock()
+
+    def start(self, requests: AsyncIterator[rpcstream_pb2.RpcStreamPacket]) -> None:
+        self._server_task = asyncio.create_task(self._run_server())
+        self._input_task = asyncio.create_task(self._run_input(requests))
+
+    def _remember_failure(self, error: BaseException) -> None:
+        if isinstance(
+            error, (asyncio.CancelledError, StreamClosedError, EOFError, CallError)
+        ):
+            return
+        if self._failure is None:
+            self._failure = error
+
+    async def _run_server(self) -> None:
+        try:
+            await self._server.serve(self._server_stream)
+        except BaseException as exc:
+            self._remember_failure(exc)
+            raise
+
+    async def _run_input(
+        self, requests: AsyncIterator[rpcstream_pb2.RpcStreamPacket]
+    ) -> None:
+        try:
+            await self._copy_requests(requests)
+        except BaseException as exc:
+            self._remember_failure(exc)
+            raise
+
+    async def _copy_requests(
+        self, requests: AsyncIterator[rpcstream_pb2.RpcStreamPacket]
+    ) -> None:
+        try:
+            async for request in requests:
+                if request.WhichOneof("body") != "data":
+                    raise RpcStreamProtocolError("unexpected nested stream packet")
+                await _write_all(self._client, _frame_inner_packet(bytes(request.data)))
+            await self._client.write_eof()
+        except BaseException:
+            await self._client.aclose()
+            raise
+
+    async def responses(self) -> AsyncIterator[rpcstream_pb2.RpcStreamPacket]:
+        decoder = PacketDecoder()
+        while True:
+            try:
+                data = await self._client.read(65_536)
+            except StreamClosedError:
+                if self._cancelled:
+                    raise
+                return
+            if not data:
+                decoder.finish()
+                return
+            for packet in decoder.feed(data):
+                yield _unframe_inner_packet(packet)
+
+    async def _close_streams(self) -> None:
+        await self._client.aclose()
+        await self._server_stream.aclose()
+
+    async def cancel(self) -> None:
+        """Wake both pumps after the registry has removed the component."""
+        self._cancelled = True
+        await self._close_streams()
+
+    async def aclose(self) -> None:
+        async with self._close_lock:
+            if self._closed:
+                return
+            self._closed = True
+            await self._close_streams()
+            for task in (self._input_task, self._server_task):
+                if task is not None and not task.done():
+                    task.cancel()
+            for task in (self._input_task, self._server_task):
+                if task is not None:
+                    with contextlib.suppress(asyncio.CancelledError, Exception):
+                        await task
+            if not self._released:
+                self._released = True
+                if self._on_release is not None:
+                    result = self._on_release()
+                    if result is not None:
+                        await result
+            if self._failure is not None and not self._cancelled:
+                raise self._failure
+
+
+async def handle_rpc_stream(
+    requests: AsyncIterator[rpcstream_pb2.RpcStreamPacket],
+    components: ComponentRegistry,
+) -> AsyncGenerator[rpcstream_pb2.RpcStreamPacket, None]:
+    """Acknowledge one component and proxy its framed packets through a Server."""
+    try:
+        first = await anext(requests)
+    except StopAsyncIteration as exc:
+        raise RpcStreamProtocolError(
+            "closed before nested stream initialization"
+        ) from exc
+    if first.WhichOneof("body") != "init":
+        raise RpcStreamProtocolError("expected nested stream initialization")
+    component_id = first.init.component_id
+    try:
+        route = await components._acquire(component_id)
+    except ComponentNotFoundError as exc:
+        yield rpcstream_pb2.RpcStreamPacket(ack=rpcstream_pb2.RpcAck(error=str(exc)))
+        return
+
+    try:
+        route.start(requests)
+        yield rpcstream_pb2.RpcStreamPacket(ack=rpcstream_pb2.RpcAck())
+        async for response in route.responses():
+            yield response
+    finally:
+        try:
+            await route.aclose()
+        finally:
+            await components._release(route)
+
+
+__all__ = [
+    "DEFAULT_INNER_CAPACITY",
+    "ComponentNotFoundError",
+    "ComponentRegistry",
+    "RpcStreamError",
+    "RpcStreamProtocolError",
+    "RpcStreamRemoteError",
+    "build_rpc_stream_open_stream",
+    "handle_rpc_stream",
+]

--- a/starpc/server.py
+++ b/starpc/server.py
@@ -87,13 +87,15 @@ class Server:
                 else:
                     await call.finish()
         finally:
-            if abort_task is not None and not abort_task.done():
-                abort_task.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
+            if abort_task is not None:
+                if not abort_task.done():
+                    abort_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
                     await abort_task
-            if handler_task is not None and not handler_task.done():
-                handler_task.cancel()
-                with contextlib.suppress(asyncio.CancelledError, CallError):
+            if handler_task is not None:
+                if not handler_task.done():
+                    handler_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
                     await handler_task
             if call is not None:
                 await call.aclose()


### PR DESCRIPTION
Python could not open a StarPC call through an existing RPC stream. Servers also lacked a registry that could route nested calls to a component. Resource clients therefore could not use Python with the nested call lifecycle already supported by Go and TypeScript.

Add `ComponentRegistry` for component lookup and `build_rpc_stream_open_stream` for nested clients. The transport reuses the existing packet codec and `Call` runtime.

    registry = ComponentRegistry()
    await registry.register("worker", server)
    nested = build_rpc_stream_open_stream("worker", caller)

Each route retains its input and response tasks until cleanup completes. A route reports protocol failures after cleanup, releases its component once, and prevents component reuse while calls are active. Server cleanup retrieves completed child failures without replacing parent cancellation.

The reciprocal Go, TypeScript, and Python fixtures cover later data, cancellation, missing and released components, release during an active call, terminal errors, and abrupt close. Ordinary calls keep their existing API and wire behavior, while Python gains the maintained nested stream lifecycle.